### PR TITLE
Update the link to Meetup page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 _site
 .sass-cache
+
+.jekyll-metadata

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@ layout: home
   </p>
 
   <p>
-    We are currently in the process of creating a meetup page (will update this page once that process is complete),
+    We have a <a href="http://www.meetup.com/Chennai-Elixir-Users-Group">Meetup</a> page,
     use <a href="https://elixir-chennai.slack.com">Slack</a> for chat,
     and have a <a href="http://groups.google.com/forum/#!forum/elixir-chennai">mailing list</a> and we are on <a href="http://twitter.com/elixirchennai">Twitter</a> too - please feel free to join all these modes of communication.
   </p>


### PR DESCRIPTION
We now have a meetup page at http://www.meetup.com/Chennai-Elixir-Users-Group

This PR adds the link to the meetup page in our homepage.
